### PR TITLE
[PERFORJ-65] Expose contextData of the InvocationContext to Jexl expressions

### DIFF
--- a/src/main/java/org/perf4j/aop/AbstractEjbTimingAspect.java
+++ b/src/main/java/org/perf4j/aop/AbstractEjbTimingAspect.java
@@ -5,6 +5,7 @@ import org.perf4j.LoggingStopWatch;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 /**
  * This is the base class for TimingAspects that use the EJB interceptor framework.
@@ -49,6 +50,10 @@ public abstract class AbstractEjbTimingAspect extends AgnosticTimingAspect {
                         }
                         
                         public Class<?> getDeclaringClass() { return (executingMethod == null) ? null : executingMethod.getDeclaringClass() ; }
+
+                        public Map<String,Object> getContextData() {
+                            return ctx.getContextData();
+                        }
                     },
                     profiled,
                     newStopWatch(profiled.logger(), profiled.level())

--- a/src/main/java/org/perf4j/aop/AbstractJoinPoint.java
+++ b/src/main/java/org/perf4j/aop/AbstractJoinPoint.java
@@ -1,5 +1,7 @@
 package org.perf4j.aop;
 
+import java.util.Map;
+
 /**
  * AOP-framework agnostic join point.
  *
@@ -19,33 +21,40 @@ public interface AbstractJoinPoint {
      * @return result of proceeding
      * @throws Throwable thrown exception
      */
-    public Object proceed() throws Throwable;
+    Object proceed() throws Throwable;
 
     /**
      * Returns an object whose method was annotated (profiled).
      *
      * @return an object whose method was annotated
      */
-    public Object getExecutingObject();
+    Object getExecutingObject();
 
     /**
      * Returns a parameters (arguments) array of processing method.
      *
      * @return array of parameters
      */
-    public Object[] getParameters();
+    Object[] getParameters();
 
     /**
      * Returns a processing method name.
      *
      * @return processing method name
      */
-    public String getMethodName();
+    String getMethodName();
 
     /**
      * Returns the declaring class of the method that was annotated.
      *
      * @return the declaring class of the method that was annotated
      */
-    public Class<?> getDeclaringClass();
+    Class<?> getDeclaringClass();
+
+    /**
+     * Returns the context data of the invocation context.
+     *
+     * @return the context data of the invocation context
+     */
+    Map<String, Object> getContextData();
 }

--- a/src/main/java/org/perf4j/aop/AbstractTimingAspect.java
+++ b/src/main/java/org/perf4j/aop/AbstractTimingAspect.java
@@ -15,6 +15,10 @@
  */
 package org.perf4j.aop;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -53,6 +57,10 @@ public abstract class AbstractTimingAspect extends AgnosticTimingAspect {
                     public String getMethodName() { return pjp.getSignature().getName(); }
                     
                     public Class<?> getDeclaringClass() { return pjp.getSignature().getDeclaringType(); }
+
+                    public Map<String, Object> getContextData() {
+                        return Collections.emptyMap();
+                    }
                 },
                 profiled,
                 newStopWatch(profiled.logger() + "", profiled.level())

--- a/src/main/java/org/perf4j/aop/AgnosticTimingAspect.java
+++ b/src/main/java/org/perf4j/aop/AgnosticTimingAspect.java
@@ -92,7 +92,8 @@ public class AgnosticTimingAspect {
                                joinPoint.getExecutingObject(),
                                joinPoint.getDeclaringClass(),
                                returnValue,
-                               exceptionThrown);
+                               exceptionThrown,
+                               joinPoint.getContextData());
         } else {
             tag = profiled.tag();
         }
@@ -123,7 +124,8 @@ public class AgnosticTimingAspect {
                                    joinPoint.getExecutingObject(),
                                    joinPoint.getDeclaringClass(),
                                    returnValue,
-                                   exceptionThrown);
+                                   exceptionThrown,
+                                   joinPoint.getContextData());
             if ("".equals(message)) {
                 message = null;
             }
@@ -157,7 +159,8 @@ public class AgnosticTimingAspect {
                                   Object annotatedObject,
                                   Class<?> annotatedClass,
                                   Object returnValue,
-                                  Throwable exceptionThrown) {
+                                  Throwable exceptionThrown,
+                                  Map<String, Object> contextData) {
         StringBuilder retVal = new StringBuilder(text.length());
 
         //create a JexlContext to be used in all evaluations
@@ -170,6 +173,7 @@ public class AgnosticTimingAspect {
         jexlContext.getVars().put("$class", annotatedClass);
         jexlContext.getVars().put("$return", returnValue);
         jexlContext.getVars().put("$exception", exceptionThrown);
+        jexlContext.getVars().put("$contextData", contextData);
 
         // look for {expression} in the passed in text
         int bracketIndex;

--- a/src/test/java/org/perf4j/aop/EjbAopTest.java
+++ b/src/test/java/org/perf4j/aop/EjbAopTest.java
@@ -72,7 +72,11 @@ public class EjbAopTest extends TestCase {
 
                                 public void setParameters(Object[] objects) { /* not supported */ }
 
-                                public Map<String, Object> getContextData() { return new HashMap<String, Object>(); }
+                                public Map<String, Object> getContextData() {
+                                    final HashMap<String, Object> contextData = new HashMap<String, Object>();
+                                    contextData.put("whateverYouNeed", "allIWant");
+                                    return contextData;
+                                }
 
                                 public Object proceed() throws Exception { return method.invoke(beanInstance, args); }
                             };
@@ -91,5 +95,9 @@ public class EjbAopTest extends TestCase {
 
         assertEquals(100, profiledObject.simpleTestWithProfiled(100));
         assertTrue(EjbInMemoryTimingAspect.getLastLoggedString().contains("tag[usingProfiled]"));
+
+        profiledObject.simpleTestTagMessageFromContextData(5);
+        assertTrue("Expected tag not found in " + EjbInMemoryTimingAspect.getLastLoggedString(),
+                EjbInMemoryTimingAspect.getLastLoggedString().contains("tag[allIWant]"));
     }
 }

--- a/src/test/java/org/perf4j/aop/EjbProfiledObject.java
+++ b/src/test/java/org/perf4j/aop/EjbProfiledObject.java
@@ -18,4 +18,17 @@ public class EjbProfiledObject implements EjbProfiledObjectInterface {
         Thread.sleep(sleepTime);
         return sleepTime;
     }
+
+    /**
+     * See contextData from InvocationContext for expected tag
+     * @param sleepTime
+     * @return
+     * @throws Exception
+     */
+    @Interceptors(EjbInMemoryTimingAspect.class)
+    @Profiled(tag = "{$contextData.get(\"whateverYouNeed\")}")
+    public long simpleTestTagMessageFromContextData(long sleepTime) throws Exception {
+        Thread.sleep(sleepTime);
+        return sleepTime;
+    }
 }

--- a/src/test/java/org/perf4j/aop/EjbProfiledObjectInterface.java
+++ b/src/test/java/org/perf4j/aop/EjbProfiledObjectInterface.java
@@ -7,4 +7,7 @@ public interface EjbProfiledObjectInterface {
     long simpleTest(long sleepTime) throws Exception;
 
     long simpleTestWithProfiled(long sleepTime) throws Exception;
+
+    long simpleTestTagMessageFromContextData(long sleepTime) throws Exception;
+
 }


### PR DESCRIPTION
You can retrieve information by using :

`````` "{$contextData.get(\"whateverYouNeed\")}"```
```"{$contextData[\"whateverYouNeed\"]}"```

``````
