### PR TITLE
Added test for GroupedTimingStatistics with setCreateRollupStatistics(tr...

### DIFF
--- a/src/test/java/org/perf4j/GroupedTimingStatisticsTest.java
+++ b/src/test/java/org/perf4j/GroupedTimingStatisticsTest.java
@@ -64,8 +64,59 @@ public class GroupedTimingStatisticsTest extends TestCase {
         assertOutputContains(groupStatistics.toString(), "a           1.1           4           3         0.2           5           6");
     }
 
+    private static class TestStopWatch extends StopWatch {
 
+        private static final long serialVersionUID = 1L;
 
+        private String tag;
+
+        private long elapsedTime;
+
+        @Override
+        public String getTag() {
+            return tag;
+        }
+
+        @Override
+        public StopWatch setTag(String tag) {
+            this.tag = tag;
+            return this;
+        }
+
+        @Override
+        public long getElapsedTime() {
+            return elapsedTime;
+        }
+
+        public void setElapsedTime(long elapsedTime) {
+            this.elapsedTime = elapsedTime;
+        }
+    }
+
+    public void testCreateRollupStatistics() throws Exception {
+
+        GroupedTimingStatistics groupStatistics = new GroupedTimingStatistics();
+        groupStatistics.setCreateRollupStatistics(true);
+
+        TestStopWatch s = new TestStopWatch();
+        s.setTag("a.1");
+        s.setElapsedTime(10);
+        groupStatistics.addStopWatch(s);
+
+        s.setTag("a.2");
+        s.setElapsedTime(20);
+        groupStatistics.addStopWatch(s);
+
+        s.setTag("a");
+        s.setElapsedTime(20);
+        groupStatistics.addStopWatch(s);
+
+        System.out.println(groupStatistics.toString());
+        assertOutputContains(groupStatistics.toString(), "Tag     Avg(ms)         Min         Max     Std-Dev       Count       Total");
+        assertOutputContains(groupStatistics.toString(), "a          16.7          10          20         4.7           3          50");
+        assertOutputContains(groupStatistics.toString(), "a.1        10.0          10          10         0.0           1          10");
+        assertOutputContains(groupStatistics.toString(), "a.2        20.0          20          20         0.0           1          20");
+    }
 
     private void assertOutputContains(String output, String expectedToContain) {
         String message = "Expected toString() output to contain the given string, matching formatting.\n" + expectedToContain +

--- a/src/test/java/org/perf4j/LoggingStopWatchTest.java
+++ b/src/test/java/org/perf4j/LoggingStopWatchTest.java
@@ -16,6 +16,8 @@
 package org.perf4j;
 
 import junit.framework.TestCase;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.io.ByteArrayInputStream;
@@ -160,15 +162,19 @@ public class LoggingStopWatchTest extends TestCase {
         LoggingStopWatch cloneCopy = stopWatch.clone();
         assertEquals(stopWatch, cloneCopy);
 
+        ObjectOutputStream os = null;
         try {
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            new ObjectOutputStream(os).writeObject(stopWatch);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            os = new ObjectOutputStream(bos);
+            os.writeObject(stopWatch);
             LoggingStopWatch serializedCopy =
-                    (LoggingStopWatch) new ObjectInputStream(new ByteArrayInputStream(os.toByteArray())).readObject();
+                    (LoggingStopWatch) new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray())).readObject();
             assertEquals(stopWatch, serializedCopy);
             assertEquals(cloneCopy, serializedCopy);
         } catch (Exception e) {
             fail("Unexpected Exception: " + e);
+        } finally {
+            IOUtils.closeQuietly(os);
         }
     }
 


### PR DESCRIPTION
This is a new test I've had in my sandbox for a while, relating to a query on the list about rolled-up stats generation.

Also cleans-up a warning or two in test code.
